### PR TITLE
featch(GDE-5504): Zookeeper update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
       thread_safe (~> 0.1)
     zk (1.9.6)
       zookeeper (~> 1.4.0)
-    zookeeper (1.4.11)
+    zookeeper (1.5.5)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
This is just an library update to allow compability with Ubuntu 20.04